### PR TITLE
Add ty type checking and improve make help

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@
     check-all \
     check-lint \
     check-lock \
+    check-types \
     clean \
     fix-all \
     fix-format \
@@ -16,49 +17,68 @@
     run-tests \
     sync
 
+## Run all checks and tests
 default: check-all run-tests
 
+## Build source distribution
 build-dist: sync
 	uv build --verbose --sdist
 
-check-all: check-lock check-lint
+## Run all checks (lock, lint, types)
+check-all: check-lock check-lint check-types
 
+## Run ruff linter
 check-lint: check-lock
 	uv run ruff check
 
+## Verify uv.lock is up to date
 check-lock:
 	uv lock --locked
 
+## Run ty type checker
+check-types: check-lock
+	uv tool run ty check
+
+## Remove build artifacts and caches
 clean:
 	rm -rf .ruff_cache .venv build .cache *.egg-info dist $(TARGET) $(TMPTARGET) $(TARGET_DECB) $(TMPTARGET_DECB) $(EXAMPLES_OUTPUTS)
 
+## Auto-fix formatting and lint issues, then update lock
 fix-all: fix-format fix-lint lock
 
+## Auto-format code with ruff
 fix-format: check-lock
 	uv run ruff format
 
+## Auto-fix lint issues with ruff
 fix-lint: check-lock
 	uv run ruff check --fix
 
+## Auto-fix lint issues including unsafe fixes
 fix-lint-unsafe: check-lock
 	uv run ruff check --fix --unsafe-fixes
 
+## Show this help
 help:
-	@echo ${.PHONY}
+	@grep -B1 -E '^[a-zA-Z_-]+:' $(MAKEFILE_LIST) | grep -E '^##|^[a-zA-Z_-]+:' | sed 'N;s/\n/ /' | sed 's/## \(.*\) \([a-zA-Z_-]*\):.*/\2\t\1/' | sort | awk -F'\t' '{ printf "  \033[36m%-24s\033[0m %s\n", $$1, $$2 }'
 
+## Install package
 install: check-lock build-dist
 	uv run pip install .
 
+## Install pre-commit hooks
 install-pre-commit:
 	uv run pre-commit install
 
+## Update uv.lock
 lock:
 	uv lock
 
+## Run tests with coverage
 run-tests: check-lock
 	uv run coverage run -m pytest
 	uv run coverage report --show-missing
 
+## Sync dependencies
 sync: check-lock
 	uv sync --no-install-workspace
-

--- a/README.md
+++ b/README.md
@@ -54,9 +54,10 @@ make run-tests
 
 The `Makefile` makes it easy to perform the most common operations:
 
-* `make check-all` runs linting and `uv.lock` checks
+* `make check-all` runs linting, type checks, and `uv.lock` checks
 * `make check-lint` checks for linting issues
 * `make check-lock` verifies the `uv.lock` is aligned to `pyproject.toml`
+* `make check-types` runs the `ty` type checker
 * `make clean` cleans the virtual environment and caches
 * `make default` runs a default set of checks on the code
 * `make fix-all` formats the code, fixes lint errors and runs locks `uv.lock` to `pyproject.toml`
@@ -67,7 +68,6 @@ The `Makefile` makes it easy to perform the most common operations:
 * `make install` build install the distribution
 * `make install-pre-commit` installs pre-commit hooks
 * `make lock` locks `uv.lock` to `pyproject.toml`
-* `make install-pre-commit` installs pre-commit hooks
 * `make run-tests` runs the unit tests
 * `make sync` syncs the python environment with `uv.lock`
 

--- a/mc10/mcbasic.py
+++ b/mc10/mcbasic.py
@@ -296,7 +296,7 @@ BASIC_KEYWORDS = [
 BASIC_KEYWORD_TO_TOKEN = {
     keyword: token for token, keyword in enumerate(BASIC_KEYWORDS)
 }
-BASIC_KEYWORD_TO_TOKEN["!"] = 0x21
+BASIC_KEYWORD_TO_TOKEN[b"!"] = 0x21
 
 
 def c10data_to_bas(c10data):


### PR DESCRIPTION
## Summary
- Add `check-types` Makefile target that runs the `ty` type checker, integrated into `check-all`
- Replace `make help` with a self-documenting `##` comment system that auto-generates a formatted help listing
- Fix latent bytes/str key bug in `BASIC_KEYWORD_TO_TOKEN` surfaced by `ty` (line was storing `"!"` as a str key in a `dict[bytes, int]`, so real lookups with `b"!"` never hit it)
- Update README make-target list to include `check-types` and fix a duplicate `install-pre-commit` entry

Equivalent to jamieleecho/coco-tools#38, scaled down to this repo (only 1 type error vs. 187 there).

## Test plan
- [x] `make check-all` passes (ruff lint + ty type check, 0 errors)
- [x] `make run-tests` passes (18 tests, all green)
- [x] `make help` displays formatted target list with descriptions

🤖 Generated with [Claude Code](https://claude.com/claude-code)